### PR TITLE
#42 - Fixed the safe_hex_color function.

### DIFF
--- a/R/color-provider.R
+++ b/R/color-provider.R
@@ -8,11 +8,11 @@ safe_colors = c(
 #'
 #' @export
 #' @keywords internal
-#' @param locale (character) the locale to use. Run 
+#' @param locale (character) the locale to use. Run
 #' `color_provider_locales()` for locales supported (default: en_US)
 #' @details
 #' **Methods**
-#' 
+#'
 #' - `color_name()` - color name
 #' - `safe_color_name()` - safe color name
 #' - `hex_color()` - hex color
@@ -22,7 +22,7 @@ safe_colors = c(
 #'
 #' @format NULL
 #' @usage NULL
-#' 
+#'
 #' @examples
 #' x <- ColorProvider$new()
 #' x$locale
@@ -71,8 +71,12 @@ ColorProvider <- R6::R6Class(
     },
 
     safe_hex_color = function() {
-      x <- sprintf("%x", super$random_int(0, 255))
-      x <- if (nchar(x) < 3) paste0(x, rep("0", 3 - nchar(x))) else x
+      x <- sprintf(
+        "%x%x%x",
+        super$random_int(0, 5) * 3,
+        super$random_int(0, 5) * 3,
+        super$random_int(0, 5) * 3
+      )
       paste0(
         "#",
         private$ind(x, 1), private$ind(x, 1),

--- a/tests/testthat/test-color.R
+++ b/tests/testthat/test-color.R
@@ -97,7 +97,7 @@ test_that("ch_safe_hex_color works", {
   expect_equal(length(ch_safe_hex_color()), 1)
   expect_equal(length(ch_safe_hex_color(12)), 12)
 
-  safe_hex_regex <- "^#([0-9A-F])\\1([0-9A-F])\\2([0-9A-F])\\3$"
+  safe_hex_regex <- "^#([0369CF])\\1([0369CF])\\2([0369CF])\\3$"
 
   expect_match(ch_safe_hex_color(), safe_hex_regex, ignore.case = TRUE)
   expect_match(ch_safe_hex_color(12), safe_hex_regex, ignore.case = TRUE)

--- a/tests/testthat/test-color.R
+++ b/tests/testthat/test-color.R
@@ -29,43 +29,122 @@ test_that("ColorProvider locale support works", {
 
   expect_is(bb$locale, "character")
   expect_equal(bb$locale, "uk_UA")
+
   expect_is(bb$color_name(), "character")
-  expect_true(any(grepl(bb$color_name(), names(bb$all_colors))))
+  expect_true(all(bb$color_name() %in% names(bb$all_colors)))
+
+  expect_is(bb$safe_color_name(), "character")
+  expect_true(all(bb$safe_color_name() %in% bb$safe_colors))
 })
 
+context("ch color functions work")
 
-context("color fxns works")
+test_that("ch color functions error for incorrect input", {
+  expect_error(ch_color_name(-1))
+  expect_error(ch_color_name(-99, "uk_UA"))
+  expect_error(ch_color_name(locale = "ch_AR"))
+  expect_error(ch_safe_color_name(-1))
+  expect_error(ch_safe_color_name(-99, "uk_UA"))
+  expect_error(ch_safe_color_name(locale = "ch_AR"))
+  expect_error(ch_hex_color(-99))
+  expect_error(ch_safe_hex_color(-1))
+  expect_error(ch_rgb_color(-99))
+  expect_error(ch_rgb_css_color(-1))
+})
 
-test_that("ch_color_name", {
+test_that("ch_color_name works", {
   expect_is(ch_color_name(), "character")
+  expect_is(ch_color_name(7), "character")
+
+  expect_equal(length(ch_color_name()), 1)
   expect_equal(length(ch_color_name(12)), 12)
-  expect_true(any(grepl(ch_color_name(), names(ColorProvider$new()$all_colors))))
+
+  expect_true(all(ch_color_name() %in% names(ColorProvider$new()$all_colors)))
+  expect_true(all(ch_color_name(7) %in% names(ColorProvider$new()$all_colors)))
 })
 
-test_that("ch_safe_color_name", {
+test_that("ch_safe_color_name works", {
   expect_is(ch_safe_color_name(), "character")
   expect_is(ch_safe_color_name(5), "character")
-  expect_true(any(grepl(ch_safe_color_name(), ColorProvider$new()$safe_colors)))
+
+  expect_equal(length(ch_safe_color_name()), 1)
+  expect_equal(length(ch_safe_color_name(7)), 7)
+
+  expect_true(all(ch_safe_color_name() %in% ColorProvider$new()$safe_colors))
+  expect_true(all(ch_safe_color_name(7) %in% ColorProvider$new()$safe_colors))
 })
 
-test_that("ch_hex_color", {
+test_that("ch_hex_color works", {
   expect_is(ch_hex_color(), "character")
+  expect_is(ch_hex_color(7), "character")
+
+  expect_equal(length(ch_hex_color()), 1)
   expect_equal(length(ch_hex_color(12)), 12)
-  expect_true(all(grepl("#", ch_hex_color(12))))
+
+  hex_regex <- "^#[0-9A-F]{6}$"
+
+  expect_match(ch_hex_color(), hex_regex, ignore.case = TRUE)
+  expect_match(ch_hex_color(12), hex_regex, ignore.case = TRUE)
+
+  expect_true(all(nchar(ch_hex_color()) == 7))
   expect_true(all(nchar(ch_hex_color(12)) == 7))
 })
 
+test_that("ch_safe_hex_color works", {
+  expect_is(ch_safe_hex_color(), "character")
+  expect_is(ch_safe_hex_color(7), "character")
 
-context("color and safe color matches expected format")
+  expect_equal(length(ch_safe_hex_color()), 1)
+  expect_equal(length(ch_safe_hex_color(12)), 12)
 
-test_that("ch_rgb_color", {
-  # List of length 3 elements
-  expect_is(ch_rgb_color(), "list")
-  expect_equal(vapply(ch_rgb_color(), length, 1), 3)
-  expect_equal(vapply(ch_rgb_color(2), length, 1), c(3, 3))
+  safe_hex_regex <- "^#([0-9A-F])\\1([0-9A-F])\\2([0-9A-F])\\3$"
+
+  expect_match(ch_safe_hex_color(), safe_hex_regex, ignore.case = TRUE)
+  expect_match(ch_safe_hex_color(12), safe_hex_regex, ignore.case = TRUE)
+
+  expect_true(all(nchar(ch_safe_hex_color()) == 7))
+  expect_true(all(nchar(ch_safe_hex_color(12)) == 7))
 })
 
+between_0_255 <- function(x) all(0 <= x & x <= 255)
 
+test_that("ch_rgb_color works", {
+  expect_is(ch_rgb_color(), "list")
+  expect_is(ch_rgb_color(7), "list")
+
+  expect_equal(length(ch_rgb_color()), 1)
+  expect_equal(length(ch_rgb_color(7)), 7)
+
+  expect_equal(vapply(ch_rgb_color(), length, integer(1)), rep(3, 1))
+  expect_equal(vapply(ch_rgb_color(7), length, integer(1)), rep(3, 7))
+
+  expect_true(all(vapply(ch_rgb_color(), between_0_255, logical(1))))
+  expect_true(all(vapply(ch_rgb_color(7), between_0_255, logical(1))))
+})
+
+test_that("ch_rgb_css_color works", {
+  expect_is(ch_rgb_css_color(), "character")
+  expect_is(ch_rgb_css_color(7), "character")
+
+  expect_equal(length(ch_rgb_css_color()), 1)
+  expect_equal(length(ch_rgb_css_color(7)), 7)
+
+  rgb_regex <- "^rgb\\((\\d+), (\\d+), (\\d+)\\)$"
+
+  res <- ch_rgb_css_color()
+  expect_match(res, rgb_regex)
+  expect_true(between_0_255(as.integer(gsub(rgb_regex, "\\1", res))))
+  expect_true(between_0_255(as.integer(gsub(rgb_regex, "\\2", res))))
+  expect_true(between_0_255(as.integer(gsub(rgb_regex, "\\3", res))))
+
+  res7 <- ch_rgb_css_color(7)
+  expect_match(res7, rgb_regex)
+  expect_true(between_0_255(as.integer(gsub(rgb_regex, "\\1", res7))))
+  expect_true(between_0_255(as.integer(gsub(rgb_regex, "\\2", res7))))
+  expect_true(between_0_255(as.integer(gsub(rgb_regex, "\\3", res7))))
+})
+
+context("color and safe color matches expected format")
 
 # FIXME - do these tests
 # test_that("color_name matches expected format", {


### PR DESCRIPTION
#42 - Fixed the safe_hex_color function.

## Description
The safe_hex_color function used to generate a color using the same approach as the Python faker method. I modified the function to generate only the 216 colors referenced in https://en.wikipedia.org/wiki/Web_colors#Web-safe_colors. I use the approach, "For this method I think generating three separate hex digits and duplicating them and concatenating them would be a cleaner implementation", referenced in https://github.com/ropensci/onboarding/issues/94.

## Related Issue
fix #42. Also #18 should already be fixed from a previous commit.

## Example
res <- ch_safe_hex_color(100000)
plot(table(res) / length(res))

Many tests were added for the ColorProvider functions. The few below reflect the safe_hex_color change:
safe_hex_regex <- "^#([0369CF])\\1([0369CF])\\2([0369CF])\\3$"
expect_match(ch_safe_hex_color(), safe_hex_regex, ignore.case = TRUE)
expect_match(ch_safe_hex_color(12), safe_hex_regex, ignore.case = TRUE)
expect_true(all(nchar(ch_safe_hex_color()) == 7))
expect_true(all(nchar(ch_safe_hex_color(12)) == 7))