### PR TITLE
Generate IPv4 networks, IPv6 addresses, IPv6 networks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,9 +37,9 @@ Suggests:
     testthat,
     knitr,
     rmarkdown,
-    iptools,
+    ipaddress,
     stringi
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 Collate: 
     'address-provider-en_GB.R'
     'address-provider-en_NZ.R'

--- a/R/internet-provider.R
+++ b/R/internet-provider.R
@@ -45,10 +45,13 @@
 #' x$ascii_free_email()
 #' x$ascii_company_email()
 #'
-#' # addresses, mac, ipv4
+#' # addresses, mac, ipv4, ipv6
 #' x$mac_address()
-#' if (requireNamespace("iptools", quietly=TRUE)) {
+#' if (requireNamespace("ipaddress", quietly=TRUE)) {
 #'   x$ipv4()
+#'   x$ipv4(network = TRUE)
+#'   x$ipv6()
+#'   x$ipv6(network = TRUE)
 #' }
 #'
 #' # different locales
@@ -321,25 +324,29 @@ InternetProvider <- R6::R6Class(
       tolower(self$to_ascii(xxx[2]))
     },
 
-    #' @description a ipv4 address
-    ipv4 = function() {
-      check4pkg("iptools")
-      iptools::ip_random(1)
-      # FIXME: try to do network address later
-      # if network:
-      #     address += '/' + str(self.generator.random.randint(0, IPV4LENGTH))
-      #     address = str(ip_network(address, strict=False))
-      # return address
+    #' @description an ipv4 address or network
+    #' @param network (logical) produce a network
+    ipv4 = function(network = FALSE) {
+      check4pkg("ipaddress")
+      address <- ipaddress::sample_ipv4(1)
+      if (network) {
+        prefix <- super$random_int(0, ipaddress::max_prefix_length(address))
+        address <- ipaddress::ip_network(address, prefix, strict = FALSE)
+      }
+      as.character(address)
     },
 
-    # def ipv6(self, network=False):
-    #     """Produce a random IPv6 address or network with a valid CIDR"""
-    #     address = str(ip_address(self.generator.random.randint(
-    #         2 ** IPV4LENGTH, (2 ** IPV6LENGTH) - 1)))
-    #     if network:
-    #         address += '/' + str(self.generator.random.randint(0, IPV6LENGTH))
-    #         address = str(ip_network(address, strict=False))
-    #     return address
+    #' @description an ipv6 address or network
+    #' @param network (logical) produce a network
+    ipv6 = function(network = FALSE) {
+      check4pkg("ipaddress")
+      address <- ipaddress::sample_ipv6(1)
+      if (network) {
+        prefix <- super$random_int(0, ipaddress::max_prefix_length(address))
+        address <- ipaddress::ip_network(address, prefix, strict = FALSE)
+      }
+      as.character(address)
+    },
 
     #' @description a mac address
     mac_address = function() {

--- a/man/InternetProvider.Rd
+++ b/man/InternetProvider.Rd
@@ -51,10 +51,13 @@ x$ascii_safe_email()
 x$ascii_free_email()
 x$ascii_company_email()
 
-# addresses, mac, ipv4
+# addresses, mac, ipv4, ipv6
 x$mac_address()
-if (requireNamespace("iptools", quietly=TRUE)) {
+if (requireNamespace("ipaddress", quietly=TRUE)) {
   x$ipv4()
+  x$ipv4(network = TRUE)
+  x$ipv6()
+  x$ipv6(network = TRUE)
 }
 
 # different locales
@@ -163,6 +166,7 @@ if (requireNamespace("stringi", quietly=TRUE)) {
 \item \href{#method-domain_name}{\code{InternetProvider$domain_name()}}
 \item \href{#method-domain_word}{\code{InternetProvider$domain_word()}}
 \item \href{#method-ipv4}{\code{InternetProvider$ipv4()}}
+\item \href{#method-ipv6}{\code{InternetProvider$ipv6()}}
 \item \href{#method-mac_address}{\code{InternetProvider$mac_address()}}
 \item \href{#method-uri_page}{\code{InternetProvider$uri_page()}}
 \item \href{#method-uri_path}{\code{InternetProvider$uri_path()}}
@@ -407,11 +411,35 @@ a domain word
 \if{html}{\out{<a id="method-ipv4"></a>}}
 \if{latex}{\out{\hypertarget{method-ipv4}{}}}
 \subsection{Method \code{ipv4()}}{
-a ipv4 address
+an ipv4 address or network
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{InternetProvider$ipv4()}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{InternetProvider$ipv4(network = FALSE)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{network}}{(logical) produce a network}
+}
+\if{html}{\out{</div>}}
+}
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-ipv6"></a>}}
+\if{latex}{\out{\hypertarget{method-ipv6}{}}}
+\subsection{Method \code{ipv6()}}{
+an ipv6 address or network
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{InternetProvider$ipv6(network = FALSE)}\if{html}{\out{</div>}}
+}
+
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{network}}{(logical) produce a network}
+}
+\if{html}{\out{</div>}}
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-mac_address"></a>}}

--- a/tests/testthat/test-internet.R
+++ b/tests/testthat/test-internet.R
@@ -27,3 +27,20 @@ test_that("InternetProvider works", {
   expect_match(aa$slug(), "[A-Za-z]")
 })
 
+test_that("IP address generation works", {
+  skip_if_not_installed("ipaddress")
+
+  aa <- InternetProvider$new()
+
+  expect_is(aa$ipv4(), "character")
+  expect_true(ipaddress::is_ipv4(ipaddress::ip_address(aa$ipv4())))
+
+  expect_is(aa$ipv4(network = TRUE), "character")
+  expect_true(ipaddress::is_ipv4(ipaddress::ip_network(aa$ipv4(network = TRUE))))
+
+  expect_is(aa$ipv6(), "character")
+  expect_true(ipaddress::is_ipv6(ipaddress::ip_address(aa$ipv6())))
+
+  expect_is(aa$ipv6(network = TRUE), "character")
+  expect_true(ipaddress::is_ipv6(ipaddress::ip_network(aa$ipv6(network = TRUE))))
+})


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I noticed charlatan has some TODO/FIXMEs related to generating:
- IPv4 networks
- IPv6 addresses
- IPv6 networks

My ipaddress package supports randomly sampling the IPv6 address space, and can also do the bit masking needed to generate networks for both IPv4 and IPv6.

BTW the faker module won't generate an address in a reserved network ([see here](https://github.com/joke2k/faker/blob/0df077e53924b4f51c06efef92817f81eec4edfc/faker/providers/internet/__init__.py#L37-L57)). We could achieve this using an accept-reject algorithm ([see here](https://davidchall.github.io/ipaddress/articles/ipaddress-examples.html#randomly-generate-public-addresses-1)), if this is something you're interested in?

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

None. The FIXMEs are in the code.

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

``` r
library(charlatan)

x <- InternetProvider$new()
x$ipv4()
#> [1] "190.172.2.193"
x$ipv4(network = TRUE)
#> [1] "67.64.192.0/18"
x$ipv6()
#> [1] "40dc:98a8:380:548b:8822:4e97:1fce:6942"
x$ipv6(network = TRUE)
#> [1] "fba1:738d:df08:cb00::/58"
```

<sup>Created on 2020-09-25 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
